### PR TITLE
Fix Bot vernacular name rendering issue

### DIFF
--- a/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
+++ b/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
@@ -170,7 +170,7 @@ const DynamicVoiceChat = ({ type = "" }) => {
   const { data: companyBotData } = useQuery({
     queryKey: [API_ENDPOINTS.GET_COMPANY_BOT, companySlug, flowInfo?.bot_route, languageToUse, accessToken],
     queryFn: () => getCompanyBotApi({ company_slug: companySlug, route: flowInfo.bot_route, target_language: languageToUse }),
-    enabled: !!(languageToUse && chatHistory?.length === 0 && shouldFetchIntro && isNewChatOpen && profileToUse && flowInfo?.bot_route),
+    enabled: !!(languageToUse && shouldFetchIntro && isNewChatOpen && profileToUse && flowInfo?.bot_route),
   })
 
   const { data: introMessageData, isLoading: isIntroMessageLoading } = useQuery({
@@ -795,7 +795,10 @@ const DynamicVoiceChat = ({ type = "" }) => {
     } else {
       message = introMessageData[0]?.alt_introductory_message
     }
-    const botName = introMessageData[0]?.name || "Bot"
+    const botName =
+      introMessageData[0]?.default_name ||
+      introMessageData[0]?.name ||
+      "Bot"
 
     setBotName(botName)
     setDefaultBotName(introMessageData[0]?.default_name)


### PR DESCRIPTION
## Changes
- Fixed inconsistent bot name rendering in DynamicVoiceChat
- Ensured bot name consistently uses default_name from bot_vernacular
- Removed incorrect query gating based on chatHistory.length

## Testing
- Tested multiple reloads
- Tested plus-button flow
- Verified bot_vernacular API triggers consistently
- Verified bot name no longer falls back to "Bot"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot introduction display name handling, now prioritizing preferred naming options with a fallback.
  * Enhanced logic for determining when to fetch bot introduction data, ensuring more accurate initialization in voice chat conversations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ELEVATE-Project/mohini-app-frontend/pull/301)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->