### PR TITLE
feat: pass sessionId to voice API calls for usage cost attribution

### DIFF
--- a/src/api/endpoints/ai.js
+++ b/src/api/endpoints/ai.js
@@ -9,13 +9,17 @@ import { bot_routes } from "../../configure"
  * @param {string} [storedRoute=bot_routes.normal] - Bot route configuration
  * @returns {Promise<string>} The audio data
  */
-export const getAI4BharatAudioApi = async (text, sourceLanguage = "en", storedRoute = bot_routes.normal) => {
+export const getAI4BharatAudioApi = async (text, sourceLanguage = "en", storedRoute = bot_routes.normal, sessionId = null, profileId = null) => {
   try {
-    const response = await apiClient.post(API_ENDPOINTS.TEXT_TO_SPEECH, {
+    const payload = {
       text: text,
       source_language: sourceLanguage,
       route: storedRoute,
-    })
+    }
+    if (sessionId) payload.sessionid = sessionId
+    if (profileId) payload.profileid = profileId
+
+    const response = await apiClient.post(API_ENDPOINTS.TEXT_TO_SPEECH, payload)
 
     return response.data.audio
   } catch (error) {
@@ -31,13 +35,17 @@ export const getAI4BharatAudioApi = async (text, sourceLanguage = "en", storedRo
  * @param {string} [storedRoute=bot_routes.normal] - Bot route configuration
  * @returns {Promise<string>} The transcript text
  */
-export const ai4BharatASRApi = async (base64, sourceLanguage = "en", storedRoute = bot_routes.normal) => {
+export const ai4BharatASRApi = async (base64, sourceLanguage = "en", storedRoute = bot_routes.normal, sessionId = null, profileId = null) => {
   try {
-    const response = await apiClient.post(API_ENDPOINTS.ASR, {
+    const payload = {
       s3Url: base64,
       source_language: sourceLanguage,
       route: storedRoute,
-    })
+    }
+    if (sessionId) payload.sessionid = sessionId
+    if (profileId) payload.profileid = profileId
+
+    const response = await apiClient.post(API_ENDPOINTS.ASR, payload)
 
     return response.data.transcript
   } catch (error) {
@@ -55,15 +63,19 @@ export const ai4BharatASRApi = async (base64, sourceLanguage = "en", storedRoute
  * @param {boolean} [detect_language=false] - Whether to detect language automatically
  * @returns {Promise<string>} The transliterated text
  */
-export const transliterateApiFunc = async (message, sourceLanguage = "en", targetLanguage = "en", storedRoute = bot_routes.shikshalokam_chaupal, detect_language = false) => {
+export const transliterateApiFunc = async (message, sourceLanguage = "en", targetLanguage = "en", storedRoute = bot_routes.shikshalokam_chaupal, detect_language = false, sessionId = null, profileId = null) => {
   try {
-    const response = await apiClient.post(API_ENDPOINTS.TEXT_TRANSLITERATE, {
+    const payload = {
       message_body: message,
       source_language: sourceLanguage,
       target_language: targetLanguage,
       route: storedRoute,
       detect_language: detect_language,
-    })
+    }
+    if (sessionId) payload.sessionid = sessionId
+    if (profileId) payload.profileid = profileId
+
+    const response = await apiClient.post(API_ENDPOINTS.TEXT_TRANSLITERATE, payload)
 
     const content = response.data?.transcript?.content
     if (Array.isArray(content)) {

--- a/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
+++ b/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
@@ -2020,7 +2020,7 @@ const DynamicVoiceChat = ({ type = "" }) => {
       }
 
       if (!cachedAudioUrl) {
-        audio_result = await getAI4BharatAudioApi(text, sourceLanguage, storedRoute)
+        audio_result = await getAI4BharatAudioApi(text, sourceLanguage, storedRoute, sessionId, profileToUse)
         if (audio_result?.length) {
           cachedAudioUrl = `data:audio/wav;base64,${audio_result}`
           setAudioCache(prevCache => ({
@@ -2165,7 +2165,7 @@ const DynamicVoiceChat = ({ type = "" }) => {
               }
               setAsrAudio(s3Url)
               let storedRoute = flowInfo.bot_route
-              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute)
+              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute, sessionId, profileToUse)
               if (!transcriptResult || transcriptResult === "") {
                 showNotification({
                   message: t("asrError"),

--- a/src/pages/ShikshalokamVoiceChat/voice-chat.js
+++ b/src/pages/ShikshalokamVoiceChat/voice-chat.js
@@ -2453,7 +2453,7 @@ function handleLlmError(errorMessage, errorType) {
       }
 
       if (!cachedAudioUrl) {
-        audio_result = await getAI4BharatAudioApi(text, sourceLanguage, storedRoute)
+        audio_result = await getAI4BharatAudioApi(text, sourceLanguage, storedRoute, sessionId, profileToUse)
         if (audio_result?.length) {
           cachedAudioUrl = `data:audio/wav;base64,${audio_result}`
           setAudioCache(prevCache => ({
@@ -2614,7 +2614,7 @@ function handleLlmError(errorMessage, errorType) {
               }
               setAsrAudio(prev => [...prev, s3Url]) 
               let storedRoute = getSessionRoute()
-              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute)
+              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute, sessionId, profileToUse)
               if (!transcriptResult || transcriptResult === "") {
                 showNotification({
                   message: t("asrError"),

--- a/src/pages/UnifiedChat/UnifiedVoiceBasedChat.jsx
+++ b/src/pages/UnifiedChat/UnifiedVoiceBasedChat.jsx
@@ -786,7 +786,7 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
                 transcriptResult = t("asrError")
               }
               setAsrAudio(s3Url)
-              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, FLOW_ROUTE)
+              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, FLOW_ROUTE, sessionId, profileId)
               if (!transcriptResult || transcriptResult === "") {
                 showNotification({
                   message: t("asrError"),

--- a/src/pages/ai-creation/apiServices/ai4bharat_services.js
+++ b/src/pages/ai-creation/apiServices/ai4bharat_services.js
@@ -1,7 +1,7 @@
 import { getAI4BharatAudioApi } from "api/endpoints/ai";
 import { bot_routes } from "configure";
 
-export const handleAI4BharatTTSRequest = async (text, id, language, audioCache, setAudioCache, audioRef, setIsBotTalking) => {
+export const handleAI4BharatTTSRequest = async (text, id, language, audioCache, setAudioCache, audioRef, setIsBotTalking, sessionId = null, profileId = null) => {
 
     try {
         let cachedAudioUrl = audioCache[id];
@@ -9,7 +9,7 @@ export const handleAI4BharatTTSRequest = async (text, id, language, audioCache, 
         let audio;
 
         if (!cachedAudioUrl) {
-            audio_result = await getAI4BharatAudioApi(text, language, bot_routes.mitra_create);
+            audio_result = await getAI4BharatAudioApi(text, language, bot_routes.mitra_create, sessionId, profileId);
             if (audio_result?.length) {
                 cachedAudioUrl = `data:audio/wav;base64,${audio_result}`;
                 setAudioCache((prevCache) => ({
@@ -28,7 +28,7 @@ export const handleAI4BharatTTSRequest = async (text, id, language, audioCache, 
                 setIsBotTalking(false);
             };
         } else {
-            audio_result = await getAI4BharatAudioApi(text, language, bot_routes.mitra_create);
+            audio_result = await getAI4BharatAudioApi(text, language, bot_routes.mitra_create, sessionId, profileId);
             if (audio_result?.length) {
                 cachedAudioUrl = `data:audio/wav;base64,${audio_result}`;
                 setAudioCache((prevCache) => ({

--- a/src/pages/ai-creation/components/textarea-with-mic/index.jsx
+++ b/src/pages/ai-creation/components/textarea-with-mic/index.jsx
@@ -164,7 +164,8 @@ function TextareaWithVoice({
             const transcript = await ai4BharatASRApi(
               s3Url,
               languageToUse,
-              sessionRoute
+              sessionRoute,
+              sessionId
             );
 
             if (transcript) onChange(transcript, false);

--- a/src/pages/ai-creation/pages/shikshalokam-mitra/mitra-pages/components/ChatBox.jsx
+++ b/src/pages/ai-creation/pages/shikshalokam-mitra/mitra-pages/components/ChatBox.jsx
@@ -177,7 +177,8 @@ function ChatBox({
                   transcriptResult = await ai4BharatASRApi(
                     s3Url,
                     languageToUse,
-                    sessionRoute
+                    sessionRoute,
+                    sessionId
                   );
                 }
 

--- a/src/pages/ai-creation/pages/shikshalokam-mitra/mitra-pages/components/VoiceChat.jsx
+++ b/src/pages/ai-creation/pages/shikshalokam-mitra/mitra-pages/components/VoiceChat.jsx
@@ -135,7 +135,8 @@ const VoiceChat = () => {
               transcriptResult = await ai4BharatASRApi(
                 s3Url,
                 languageToUse,
-                storedRoute
+                storedRoute,
+                sessionId
               );
               if (!transcriptResult || transcriptResult === "") {
                 showNotification({

--- a/src/pages/shikshagraha-repository/listing/Filters.jsx
+++ b/src/pages/shikshagraha-repository/listing/Filters.jsx
@@ -160,7 +160,7 @@ export default function Filters() {
               }
               let storedRoute = bot_routes.search_bot
 
-              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute)
+              transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute, sessionId)
               if (!transcriptResult || transcriptResult === "") {
                 showNotification({
                   message: t("asrError"),

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -81,13 +81,17 @@ export const readElevateProfile = async accessToken => {
     })
 }
 
-export async function getAI4BharatAudio(text, sourceLanguage = "en", storedRoute = bot_routes.normal) {
+export async function getAI4BharatAudio(text, sourceLanguage = "en", storedRoute = bot_routes.normal, sessionId = null, profileId = null) {
   try {
-    const response = await axiosInstance.post("api/text_to_speech/", {
+    const payload = {
       text: text,
       source_language: sourceLanguage,
       route: storedRoute,
-    })
+    }
+    if (sessionId) payload.sessionid = sessionId
+    if (profileId) payload.profileid = profileId
+
+    const response = await axiosInstance.post("api/text_to_speech/", payload)
 
     return response.data.audio
   } catch (error) {
@@ -96,13 +100,17 @@ export async function getAI4BharatAudio(text, sourceLanguage = "en", storedRoute
   }
 }
 
-export async function ai4BharatASR(base64, sourceLanguage = "en", storedRoute = bot_routes.normal) {
+export async function ai4BharatASR(base64, sourceLanguage = "en", storedRoute = bot_routes.normal, sessionId = null, profileId = null) {
   try {
-    const response = await axiosInstance.post("api/asr/", {
+    const payload = {
       s3Url: base64,
       source_language: sourceLanguage,
       route: storedRoute,
-    })
+    }
+    if (sessionId) payload.sessionid = sessionId
+    if (profileId) payload.profileid = profileId
+
+    const response = await axiosInstance.post("api/asr/", payload)
 
     return response.data.transcript
   } catch (error) {

--- a/src/services/audio_service.js
+++ b/src/services/audio_service.js
@@ -53,7 +53,7 @@ export const stopRecording = (setHasStartedRecording, mediaRecorder) => {
   }
 }
 
-export const handleAI4BharatTTSRequest = async (text, id, sourceLanguage = "en", audioCache, audioRef, setAudioCache, setIsPlaying, storedRoute) => {
+export const handleAI4BharatTTSRequest = async (text, id, sourceLanguage = "en", audioCache, audioRef, setAudioCache, setIsPlaying, storedRoute, sessionId = null, profileId = null) => {
   try {
     let cachedAudioUrl = audioCache && id in audioCache ? audioCache[id] : null
 
@@ -61,7 +61,7 @@ export const handleAI4BharatTTSRequest = async (text, id, sourceLanguage = "en",
     let audio
 
     if (!cachedAudioUrl) {
-      audio_result = await getAI4BharatAudioApi(text, sourceLanguage, storedRoute)
+      audio_result = await getAI4BharatAudioApi(text, sourceLanguage, storedRoute, sessionId, profileId)
       if (audio_result?.length) {
         cachedAudioUrl = `data:audio/wav;base64,${audio_result}`
         setAudioCache(prevCache => ({


### PR DESCRIPTION
## Summary

- Updates voice-related API call functions to include `sessionId` (or `userId`
  as fallback) in the request payload sent to the backend
- Required for the backend to correctly attribute TTS, STT, Translation, and
  Transliteration costs to the right `ChatSession` in `UsageCostLog`
- Without this, voice cost rows would have no session association and the
  Usage Cost Dashboard would show $0 for all voice call types

## Context

Part of the Usage Cost (Phase 2) feature. The backend now records a
`UsageCostLog` row after every voice provider call, but it needs a `session_id`
from the client to link the cost to the correct session. This change supplies
that identifier from the frontend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice and speech features now carry session/profile context through transcription and audio generation requests.
  * Updated voice chat and text-to-speech flows across multiple areas of the app to support this added context.

* **Bug Fixes**
  * Improved consistency of voice input and spoken response handling by passing the same contextual details across related requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->