### PR TITLE
Fix: Mic behaviour

### DIFF
--- a/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
+++ b/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
@@ -2140,7 +2140,6 @@ const DynamicVoiceChat = ({ type = "" }) => {
   const startRecording = () => {
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
       handleOnStopSpeaking()
-      setTextMessage("")
       navigator.mediaDevices
         .getUserMedia({ audio: true })
         .then(stream => {
@@ -2200,7 +2199,12 @@ const DynamicVoiceChat = ({ type = "" }) => {
                   },
                 })
               } else {
-                setTextMessage(transcriptResult)
+                setTextMessage(prev => {
+                  if (prev && prev.trim().length > 0) {
+                    return prev.trimEnd() + " " + transcriptResult
+                  }
+                  return transcriptResult
+                })
               }
               setIsFetchingData(false)
             } else {

--- a/src/pages/UnifiedChat/UnifiedVoiceBasedChat.jsx
+++ b/src/pages/UnifiedChat/UnifiedVoiceBasedChat.jsx
@@ -739,7 +739,6 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
   const startRecording = () => {
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
       handleOnStopSpeaking()
-      setTextMessage("")
       navigator.mediaDevices
         .getUserMedia({ audio: true })
         .then(stream => {
@@ -798,7 +797,12 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
                   },
                 })
               } else {
-                setTextMessage(transcriptResult)
+                setTextMessage(prev => {
+                  if (prev && prev.trim().length > 0) {
+                    return prev.trimEnd() + " " + transcriptResult
+                  }
+                  return transcriptResult
+                })
               }
               setIsFetchingData(false)
             } else {


### PR DESCRIPTION
## Summary
Fix mic button overwriting existing text instead of appending to it in PTM chat and common-chat pages.

## Changes
- `dynamic-voice-chat.js`: Removed `setTextMessage("")` from `startRecording` and updated the ASR result handler to append transcript to existing input instead of replacing it
- `UnifiedVoiceBasedChat.jsx`: Same two changes as above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice-to-text now preserves any text already typed in the message box when recording speech.
  * Recognized speech is appended to existing input instead of replacing it, making it easier to combine typing and dictation.
  * Starting a recording no longer clears the current message draft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->