### PR TITLE
Fix: Audio file

### DIFF
--- a/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
+++ b/src/pages/ShikshalokamVoiceChat/dynamic-voice-chat.js
@@ -65,7 +65,7 @@ const DynamicVoiceChat = ({ type = "" }) => {
   const { flow: storageFlow } = useUrlFlow()
 
   // ========== useState Hooks ==========
-  const [asrAudio, setAsrAudio] = useState(null)
+  const [asrAudio, setAsrAudio] = useState([])
   const [audioCache, setAudioCache] = useState({})
   const [botNameToDisplay, setBotNameToDisplay] = useState("Bot")
   const [companySlug, setCompanySlug] = useState("")
@@ -608,10 +608,10 @@ const DynamicVoiceChat = ({ type = "" }) => {
     sendSocketMessage({
       text: textMessage,
       context: "",
-      asr_audio: asrAudio,
+      asr_audio: asrAudio && asrAudio.length > 0 ? asrAudio.join(',') : null,
     })
 
-    setAsrAudio(null)
+    setAsrAudio([])
     handleScrollToView()
     setTextMessage("")
   }
@@ -2165,7 +2165,7 @@ const DynamicVoiceChat = ({ type = "" }) => {
               if (!s3Url || s3Url === "") {
                 transcriptResult = t("asrError")
               }
-              setAsrAudio(s3Url)
+              setAsrAudio(prev => [...prev, s3Url])
               let storedRoute = flowInfo.bot_route
               transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, storedRoute)
               if (!transcriptResult || transcriptResult === "") {

--- a/src/pages/UnifiedChat/UnifiedVoiceBasedChat.jsx
+++ b/src/pages/UnifiedChat/UnifiedVoiceBasedChat.jsx
@@ -38,7 +38,7 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
   const [localChatHistory, setLocalChatHistory, removeLocalChatHistory] = useSmartChatStorage()
   const [chatHistory, setChatHistory] = useState(!!localChatHistory?.length ? localChatHistory : [])
   const [textMessage, setTextMessage] = useState("")
-  const [asrAudio, setAsrAudio] = useState(null)
+  const [asrAudio, setAsrAudio] = useState([])
   const [isFetchingData, setIsFetchingData] = useState(false)
   const [reconText, setReconText] = useState("")
   const [audioCache, setAudioCache] = useState({})
@@ -784,7 +784,7 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
               if (!s3Url || s3Url === "") {
                 transcriptResult = t("asrError")
               }
-              setAsrAudio(s3Url)
+              setAsrAudio(prev => [...prev, s3Url])
               transcriptResult = await ai4BharatASRApi(s3Url, languageToUse, FLOW_ROUTE)
               if (!transcriptResult || transcriptResult === "") {
                 showNotification({
@@ -842,7 +842,7 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
       setHasStartedListening(false)
       setHasStartedRecording(false)
       setTextMessage("")
-      setAsrAudio(null)
+      setAsrAudio([])
       setIntervalId(null)
       setSeconds(0)
       setMediaRecorder(null)
@@ -1058,7 +1058,7 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
                   answer: textMessage,
                   language: languageToUse,
                   sent_at: new Date().toISOString(),
-                  audio_url: asrAudio,
+                  audio_url: asrAudio && asrAudio.length > 0 ? asrAudio.join(',') : null,
                   service: last_question.service || null,
                 }
                 savePTMQuestionApi(data)
@@ -1074,7 +1074,7 @@ const UnifiedVoiceBasedChat = ({ flowType }) => {
                   },
                 ])
                 setTextMessage("")
-                setAsrAudio(null)
+                setAsrAudio([])
                 setHasStartedListening(false)
                 setIsFetchingData(false)
                 setHasStartedRecording(false)


### PR DESCRIPTION
## Summary
Fix audio URL accumulation in common-chat and PTM chat so that multiple recordings made before sending a message are all saved to the admin panel, matching guest-mi behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice chat handling so multiple recorded audio clips are preserved and sent together instead of being overwritten.
  * Reset voice recording state more reliably after sending a message or submitting a question.
  * Ensured audio payloads are empty when no recordings exist, reducing the chance of sending incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->